### PR TITLE
Handling of multiple resultsets for queries with multiple statements

### DIFF
--- a/Products/ZPyODBCDA/pyodbc_db.py
+++ b/Products/ZPyODBCDA/pyodbc_db.py
@@ -143,8 +143,6 @@ class DB(TM):
                         o_result = o_cur.fetchmany(pl_maxRows)
                 if not o_cur.nextset():
                     break
-        except:
-            raise
         finally:
             o_cur.close()
 

--- a/Products/ZPyODBCDA/pyodbc_db.py
+++ b/Products/ZPyODBCDA/pyodbc_db.py
@@ -132,17 +132,20 @@ class DB(TM):
             o_cur = self._cursor()
             o_ret = o_cur.execute(ps_queryString)
         
-        while True:
-            o_desc = o_cur.description
-       
-            if pl_maxRows == None:
-                o_result = o_cur.fetchmany(self._MaxRows)
-            else:
-                o_result = o_cur.fetchmany(pl_maxRows)
-            if not o_cur.nextset():
-                break
-
-        o_cur.close()
+        try:
+            while True:
+                o_desc = o_cur.description
+        
+                if pl_maxRows == None:
+                    o_result = o_cur.fetchmany(self._MaxRows)
+                else:
+                    o_result = o_cur.fetchmany(pl_maxRows)
+                if not o_cur.nextset():
+                    break
+        except:
+            raise
+        finally:
+            o_cur.close()
 
         if o_desc is None:
             return (), ()

--- a/Products/ZPyODBCDA/pyodbc_db.py
+++ b/Products/ZPyODBCDA/pyodbc_db.py
@@ -131,10 +131,20 @@ class DB(TM):
             self._cursor = self._conx.cursor
             o_cur = self._cursor()
             o_ret = o_cur.execute(ps_queryString)
-        o_desc = o_cur.description
+        
+        while True:
+            o_desc = o_cur.description
+       
+            if pl_maxRows == None:
+                o_result = o_cur.fetchmany(self._MaxRows)
+            else:
+                o_result = o_cur.fetchmany(pl_maxRows)
+            if not o_cur.nextset():
+                break
+
+        o_cur.close()
 
         if o_desc is None:
-            o_cur.close()
             return (), ()
 
         o_items = map(lambda x: {'name': x[0], 'type': x[1], 'dsize': x[2],
@@ -152,13 +162,6 @@ class DB(TM):
         float_field_ids = [i for i in range(len(field_types))
                            if field_types[i] in (float,)
                           ]
-
-        if pl_maxRows == None:
-            o_result = o_cur.fetchmany(self._MaxRows)
-        else:
-            o_result = o_cur.fetchmany(pl_maxRows)
-
-        o_cur.close()
 
         # JJ: Make sure all names are strings (utf-8 encoded)
         def to_string(val):

--- a/Products/ZPyODBCDA/pyodbc_db.py
+++ b/Products/ZPyODBCDA/pyodbc_db.py
@@ -136,10 +136,11 @@ class DB(TM):
             while True:
                 o_desc = o_cur.description
         
-                if pl_maxRows == None:
-                    o_result = o_cur.fetchmany(self._MaxRows)
-                else:
-                    o_result = o_cur.fetchmany(pl_maxRows)
+                if o_desc:
+                    if pl_maxRows == None:
+                        o_result = o_cur.fetchmany(self._MaxRows)
+                    else:
+                        o_result = o_cur.fetchmany(pl_maxRows)
                 if not o_cur.nextset():
                     break
         except:


### PR DESCRIPTION
Currently we are only receiving the first resultset of a multistatement query. This also affects the Exception handling since pyodbc is only raising errors when the cursor is handling the corresponding resultset. We are now iterating over all resultsets and returning the last.