### PR TITLE
T235131: Close connection in rollback exception so it's reopened later

### DIFF
--- a/Products/ZPyODBCDA/pyodbc_db.py
+++ b/Products/ZPyODBCDA/pyodbc_db.py
@@ -276,7 +276,7 @@ class DB(TM):
         try:
             self._conx.rollback()
         except DB_Error:
-            raise
+            self._conx.close()
 
     def _begin(self):
         pass


### PR DESCRIPTION
This change aims to allow us to reopen the connection in the event that rollback is being performed and the connection to the database gets dropped during that process, normally resulting in connection error. This change was tested on froneri dev system with a simulated case of a hard error forcing a rollback and dropping of the connection. For  more context and information refer to T235131 ticket